### PR TITLE
Fix kerSORT

### DIFF
--- a/pkg/R/Rallfun-v41.R
+++ b/pkg/R/Rallfun-v41.R
@@ -59496,8 +59496,8 @@ kerSORT<-function(x,xlab='',ylab='',pts=NA){
 #
 #
 A=min(c(sd(x),idealfIQR(x)/1.34))
-bw=.9*A/n^.2
-init=density(x,bw=bw,kernel='ep')
+bw=1.06*A/length(x)^.2
+init=density(x,bw=bw,kernel='epanechnikov')
 plot(init$x,init$y,xlab=xlab,ylab=ylab,type='n')
 lines(init$x,init$y)
 }


### PR DESCRIPTION
Greetings.
This PR does two things:
1. Fix bug in `kerSORT()`
2. Adjusts value of `bw` to the formula in the 5th ed. book, p.49
![image](https://github.com/nicebread/WRS/assets/15340708/28c18cc6-225c-4eb1-b36f-b3d25479de60)
