### PR TITLE
Fix shiftQSci() to pass args into shiftes() for locfun

### DIFF
--- a/pkg/R/Rallfun-v41.R
+++ b/pkg/R/Rallfun-v41.R
@@ -61671,11 +61671,11 @@ y=elimna(y)
 n1=length(x)
 n2=length(y)
 v=NA
-ef=shiftes(x,y,locfun=locfun,SEED=FALSE)$Q.Effect
+ef=shiftes(x,y,locfun=locfun,SEED=FALSE, ...)$Q.Effect
 for(i in 1:nboot){
 X=sample(x,n1,replace=TRUE)
 Y=sample(y,n2,replace=TRUE)
-v[i]=shiftes(X,Y,locfun=locfun,SEED=FALSE)$Q.Effect
+v[i]=shiftes(X,Y,locfun=locfun,SEED=FALSE, ...)$Q.Effect
 }
 v=sort(v)
 ilow<-round((alpha/2) * nboot)


### PR DESCRIPTION
Greetings.
This fix ensures that arguments for the underlying function `shiftes()` are passed from the `shiftQSci()` wrapper. Btw, I've noticed that some other functions using `shiftes()` also don't get these additional arguments, but haven't fixed them because not sure about their purpose yet. Please take a look into this.

With kind regards,
s4rduk4r