### PR TITLE
Include critical values for Yuen's t-bootstrap method

### DIFF
--- a/pkg/R/Rallfun-v44.R
+++ b/pkg/R/Rallfun-v44.R
@@ -8168,8 +8168,11 @@ if(test<0)G=mean(test>tval[1:nboot])
 if(test>=0)G=mean(test<tval[1:nboot])
 p.value=2*G
 }
-list(ci=CI,test.stat=test,p.value=p.value,est.1=mean(x,tr),est.2=mean(y,tr),est.dif=mean(x,tr)-mean(y,tr),
-n1=length(x),n2=length(y))
+result = list(ci=CI,test.stat=test,crit=crit,p.value=p.value,
+              est.1=mean(x,tr),est.2=mean(y,tr),est.dif=mean(x,tr)-mean(y,tr),
+              n1=length(x),n2=length(y))
+if(side) { result$crit = tval[icrit] }
+result
 }
 
 


### PR DESCRIPTION
This PR adds output of critical values for Yuen's t-bootstrap method in function `yuenbt`. Previous implementation used them internally, but haven't exposed them to user. The actual changes to the file were made on the rows 8171-8176, please look at the attached image below.
![image](https://github.com/user-attachments/assets/3dc2016b-a664-4476-beed-eda464d1376c)