### PR TITLE
Fix p.value calculation in b1way() function

### DIFF
--- a/pkg/R/Rallfun-v44.R
+++ b/pkg/R/Rallfun-v44.R
@@ -10053,7 +10053,7 @@ bvec[j,]<-apply(data,1,est,...) # A J by nboot matrix
 }
 teststat<-wsumsq(gest,nval)
 testb<-apply(bvec,2,wsumsq,nval)
-p.value<-1 - sum(teststat >= testb)/nboot
+p.value<-1 - sum(teststat >= testb, na.rm = TRUE)/nboot
 teststat<-wsumsq(gest,nval)
 if(teststat == 0)p.value <- 1
 list(teststat=teststat,p.value=p.value)


### PR DESCRIPTION
This PR fixes `p.value` calculation from getting NA in some cases, and, as a result, rendering SHB method useless. The actual change has been made in row 10056. Please look at the screenshot below
![image](https://github.com/user-attachments/assets/218f0370-78e8-4a45-9da8-abf7d45a2b26)

P.S. I apologize for producing those horribly long diff files, but it's how my local version of `git` behaves. It might be somehow related to the fact that the actual commits are done in WSL2 (which is Linux environment), while the actual changes to the code were made in Windows environment